### PR TITLE
Disabling 'add note' button

### DIFF
--- a/app/assets/javascripts/notes.js
+++ b/app/assets/javascripts/notes.js
@@ -5,4 +5,8 @@ jQuery(document).on('ready page:load',function() {
      		$('#new_note').submit();
      	}
      })
+
+     $('#new_note #note_text').on('input', function() {
+     	$('#submit_button').attr('disabled', $(this).val().trim() == '');
+     })
 });

--- a/app/views/notes/create.js.erb
+++ b/app/views/notes/create.js.erb
@@ -1,6 +1,7 @@
 $('#notes').show();
 $('#notes').append('<%= j render(@note) %>');
 $('#new_note #note_text').val('');
+$('#new_note #submit_button').attr('disabled', true);
 
 <% if @note.submission.task.notes.count == 1 %>
   $('#task_title #text').prepend('<span style="color:#f0ad4e" class="glyphicon glyphicon-exclamation-sign"></span>');

--- a/app/views/tasks/_note_form.html.erb
+++ b/app/views/tasks/_note_form.html.erb
@@ -1,5 +1,5 @@
 <%= simple_form_for Note.new, remote: true do |f| %>
   <%= f.input :text, input_html: { rows: 3 }, label: false, placeholder: "Текст замечания" %>
   <%= f.hidden_field :submission_id, value: @submission.id %>
-  <%= f.button :submit, "Добавить замечание", class: "btn btn-warning"  %>
+  <%= f.button :submit, "Добавить замечание", class: "btn btn-warning", id: "submit_button", disabled: true %>
 <% end %>


### PR DESCRIPTION
'Add note' button is now disabled when note text field is empty.